### PR TITLE
feat: always download WSLHostPatcher from latest release

### DIFF
--- a/run.js
+++ b/run.js
@@ -14,7 +14,7 @@ console.log(figlet.textSync('expose-wsl'), '\n');
 if (!existsSync(`${folder}/WSLHostPatcher.exe`)) {
   process.stdout.write('⏳ WSLHostPatcher not found, downloading... ');
   await download(
-    'https://github.com/CzBiX/WSLHostPatcher/releases/download/v0.1.1/WSLHostPatcher.zip',
+    'https://github.com/CzBiX/WSLHostPatcher/releases/latest/download/WSLHostPatcher.zip',
     `${folder}/WSLHostPatcher.zip`
   );
   process.stdout.write('extracting... ');


### PR DESCRIPTION
Change the download url to always download WSLHostPatcher latest release, the old release (v0.1.1) can't seem to work properly on the latest WSL2. 

It is already fixed on WSLHostPatcher side but it seems this tool is still using the old version

More context: https://github.com/CzBiX/WSLHostPatcher/issues/18

Thank you and great tool btw. It's been a huge help